### PR TITLE
Add pagination

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -26,7 +26,20 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/RideResponse'
+                  $ref: '#/components/schemas/PaginatedRideResponse'
+      parameters:
+        - name: limit
+          in: query
+          description: "Maximum number of rides to return. Must be >= 0. To return all rides, use 0."
+          schema:
+            type: integer
+            default: 20
+        - name: page
+          in: query
+          description: "The page of results to return. Must be > 0."
+          schema:
+            type: integer
+            default: 1
     post:
       tags:
         - rides
@@ -144,3 +157,23 @@ components:
         created:
           type: string
           description: Date of creation
+    PaginatedRideResponse:
+      type: object
+      properties:
+        total_results:
+          type: integer
+          description: total count of the rides
+        total_pages:
+          type: number
+          description: total count of pages
+        page:
+          type: number
+          description: the current page
+        limit:
+          type: number
+          description: maximum number of rides in each page
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/RideResponse'
+          description: list of rides

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1,6 +1,6 @@
 import { Database } from 'sqlite3';
 
-export const buildSchemas = (db: Database) => {
+export const buildSchemas = (db: Database, callback?: () => void) => {
   const createRideTableSchema = `
         CREATE TABLE Rides
         (
@@ -16,9 +16,12 @@ export const buildSchemas = (db: Database) => {
         )
     `;
 
-  db.run(createRideTableSchema);
+  db.run(createRideTableSchema, callback);
 
   return db;
 };
 
-export default buildSchemas;
+export const deleteSchemas = (db: Database, callback?: () => void) => {
+  db.run('DROP TABLE IF EXISTS Rides', callback);
+  return db;
+};

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,6 @@
+export const parseNumber = (value: any, defaultValue: Number): any => {
+  const num = parseInt(value, 10);
+  return Number.isNaN(num) ? defaultValue : num;
+};
+
+export default parseNumber;

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -1,0 +1,21 @@
+import assert from 'assert';
+import parseNumber from '../src/util';
+
+describe('Util tests', () => {
+
+  describe('parseNumber', () => {
+    it('should return value if valid number', () => {
+      assert.strictEqual(parseNumber('10', 20), 10)
+    });
+
+    it('should return 0 if string is 0', () => {
+      assert.strictEqual(parseNumber('0', 20), 0)
+    });
+
+    it('should return default value if invalid number', () => {
+      assert.strictEqual(parseNumber('invalid', 20), 20)
+    });
+    
+  });
+
+});

--- a/tests/util.ts
+++ b/tests/util.ts
@@ -1,0 +1,16 @@
+import { Database } from "sqlite3";
+import { buildSchemas } from "../src/schemas";
+
+export const addRide = (db: Database, callback?: () => void) => {
+    const ride = [
+        1,
+        2,
+        3,
+        4,
+        'Rider',
+        'Driver',
+        'Car',
+    ]
+
+    db.run('INSERT INTO Rides(startLat, startLong, endLat, endLong, riderName, driverName, driverVehicle) VALUES (?, ?, ?, ?, ?, ?, ?)', ride, callback);
+};


### PR DESCRIPTION
This PR updates the /rides endpoint to accept 'limit' and 'page' query parameter for pagination.

`limit` - defines the total number of rides to return in the response, can be set to 0 to return all rides
`page` - defines the current page

Documentation is also updated